### PR TITLE
feat: update built-in validators count in vine documentation

### DIFF
--- a/docs/packages/vine.md
+++ b/docs/packages/vine.md
@@ -7,7 +7,7 @@ pubdev: https://pub.dev/packages/vine
 repository: https://github.com/LeadcodeDev/vine
 features:
   - title: Built-in validators
-    value: 150+
+    value: 70+
   - title: OpenAPI support
     value: Export and share your validation schema as OpenAPI spec.
   - title: Complexe Validation

--- a/docs/packages/vine.md
+++ b/docs/packages/vine.md
@@ -17,5 +17,5 @@ features:
   - title: Composable
     value: Design independent, reusable diagrams so that you can assemble them to suit your needs.
   - title: Expandable
-    value: Vine offers over 150+ ready-to-use validation rules, but you can also create your own custom rules.
+    value: Vine offers over 70+ ready-to-use validation rules, but you can also create your own custom rules.
 ---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Vine package documentation to reflect the current number of built-in validators, changing the count from "150+" to "70+".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->