### PR TITLE
chore(fletch): bump to fletch 2.3.0

### DIFF
--- a/configs/http/fletch.yaml
+++ b/configs/http/fletch.yaml
@@ -1,6 +1,6 @@
 framework: fletch
 projectPath: frameworks/fletch
-version: 2.2.0
+version: 2.3.0
 description: A fast, Express-inspired HTTP framework for Dart. Build production-ready REST APIs 
   with built-in sessions, CORS, rate limiting, and middleware support.
 publisher: mahawarkartikey.in

--- a/frameworks/fletch/bin/fletch_bench.dart
+++ b/frameworks/fletch/bin/fletch_bench.dart
@@ -12,7 +12,7 @@ Future<void> main() async {
 
   app.get('/health', (req, res) => res.text('ok'));
 
-  // Echo raw body without JSON parse/re-encode — same work as the dart:io bench.
+  // Echo request payload back as JSON using Fletch body parsing + JSON response encoding.
   app.get('/api/echo', (req, res) async {
     final body = await req.body;
     res.json(body as Map<String, dynamic>);

--- a/frameworks/fletch/bin/fletch_bench.dart
+++ b/frameworks/fletch/bin/fletch_bench.dart
@@ -7,12 +7,12 @@ Future<void> main() async {
   final host =
       Platform.environment['HOST'] ?? InternetAddress.loopbackIPv4.address;
   final app = Fletch(
-    useCookieParser: false,
     requestTimeout: null, // disable per-request Timer — no timeout infra in bench
   );
 
   app.get('/health', (req, res) => res.text('ok'));
 
+  // Echo raw body without JSON parse/re-encode — same work as the dart:io bench.
   app.get('/api/echo', (req, res) async {
     final body = await req.body;
     res.json(body as Map<String, dynamic>);

--- a/frameworks/fletch/pubspec.lock
+++ b/frameworks/fletch/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "3b19a47f6ea7c2632760777c78174f47f6aec1e05f0cd611380d4593b8af1dbc"
+      sha256: a49d6cf99e8d8e7a8e93668d09ced0bbdb954d0b4fccc2f5f9241c6b87fad95c
       url: "https://pub.dev"
     source: hosted
-    version: "96.0.0"
+    version: "99.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "0c516bc4ad36a1a75759e54d5047cb9d15cded4459df01aa35a0b5ec7db2c2a0"
+      sha256: "663efa951fb8a45e06f491223a604c93820598f20e6a99c25617a1576065e8b7"
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.0"
+    version: "12.1.0"
   args:
     dependency: transitive
     description:
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
@@ -101,10 +109,10 @@ packages:
     dependency: "direct main"
     description:
       name: fletch
-      sha256: "373f6be6c32e253eee43bfde712e2b22a484acb97d989b6eb0e6ee0e9916c796"
+      sha256: f93be2d9e87a7cd91bf23f0cc1108e91b8fccb54430eedd0d676cc43cc0ec23b
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -173,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: logger
-      sha256: a7967e31b703831a893bbc3c3dd11db08126fe5f369b5c648a36f821979f5be3
+      sha256: "25aee487596a6257655a1e091ec2ae66bc30e7af663592cc3a27e6591e05035c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.2"
+    version: "2.7.0"
   logging:
     dependency: transitive
     description:
@@ -197,10 +205,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "9f29b9bcc8ee287b1a31e0d01be0eae99a930dbffdaecf04b3f3d82a969f296f"
+      sha256: df0c643f44ad098eb37988027a8e2b2b5a031fd3977f06bbfd3a76637e8df739
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.1"
+    version: "1.18.2"
   mime:
     dependency: transitive
     description:
@@ -357,26 +365,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:

--- a/frameworks/fletch/pubspec.yaml
+++ b/frameworks/fletch/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  fletch: ^2.2.0
+  fletch: ^2.3.0
 
 dev_dependencies:
   lints: ^6.0.0


### PR DESCRIPTION
## Summary

- Bump fletch dependency from 2.2.0 → 2.3.0 (published on pub.dev)
- Update config version to 2.3.0
- Remove unused `dart:convert` import in `fletch_bench.dart`

## What's new in 2.3.0

- **RadixRouter refactor** — static routes now use an O(1) HashMap pre-check, eliminating radix tree traversal for fully-static paths
- **`Response.send` de-async** — removes one Future state machine allocation per request, reducing GC pressure
- **Optional params** (`:id?`) and **named glob** (`*:name`) routing features
- 318 tests, 97.0% line coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded framework and package references to the 2.3.0 release.
* **Behavior Change**
  * Cookie parsing is now enabled by default in the benchmark server, so incoming cookies are automatically processed.
* **Documentation**
  * Clarified API endpoint comments to explain request/response behavior for the echo route.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->